### PR TITLE
Change default version from 5.1.34 to 5.1.38.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -75,7 +75,7 @@ Most useful available parameters:
 #####`ensure`
 Ensure the MySQL connector is installed. Defaults to present.
 #####`version`
-Specifies the version of MySQL Java Connector you would like installed. Defaults to '5.1.34' 
+Specifies the version of MySQL Java Connector you would like installed. Defaults to '5.1.38' 
 #####`product`
 Product name, defaults to 'mysql-connector-java'
 #####`format`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,7 @@
 # [*ensure*]
 #  Ensure the MySQL connector is installed. Defaults to present.
 # [*version*]
-#  Specifies the version of MySQL Java Connector you would like installed. Defaults to '5.1.34' 
+#  Specifies the version of MySQL Java Connector you would like installed. Defaults to '5.1.38' 
 # [*product*]
 #  Product name, defaults to 'mysql-connector-java'
 # [*format*]
@@ -21,7 +21,7 @@
 #
 class mysql_java_connector (
   $ensure      = 'present',
-  $version     = '5.1.34',
+  $version     = '5.1.38',
   $product     = 'mysql-connector-java',
   $format      = 'tar.gz',
   $installdir  = '/opt/MySQL-connector',

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -27,7 +27,7 @@ describe 'mysql_java_connector class' do
       it { should be_symlink }
     end
 
-    describe file('/opt/MySQL-connector/latest/mysql-connector-java-5.1.34-bin.jar') do
+    describe file('/opt/MySQL-connector/latest/mysql-connector-java-5.1.38-bin.jar') do
       it { should be_file }
       its(:md5sum) { should eq 'adaa13571f32cfb67a388b6b0acfa8e8' }
     end

--- a/spec/classes/mysql_java_connector_spec.rb
+++ b/spec/classes/mysql_java_connector_spec.rb
@@ -16,15 +16,15 @@ describe 'mysql_java_connector' do
           it { is_expected.to contain_file('/opt/MySQL-connector/latest')
             .with({
               'ensure' => 'link',
-              'target' => '/opt/MySQL-connector/mysql-connector-java-5.1.34',
+              'target' => '/opt/MySQL-connector/mysql-connector-java-5.1.38',
           })}
-          it { is_expected.to contain_staging__file('mysql-connector-java-5.1.34.tar.gz').with({
-            'source'  => 'http://cdn.mysql.com/Downloads/Connector-J/mysql-connector-java-5.1.34.tar.gz',
+          it { is_expected.to contain_staging__file('mysql-connector-java-5.1.38.tar.gz').with({
+            'source'  => 'http://cdn.mysql.com/Downloads/Connector-J/mysql-connector-java-5.1.38.tar.gz',
             'timeout' => '300',
           })}
-          it { is_expected.to contain_staging__extract('mysql-connector-java-5.1.34.tar.gz').with({
+          it { is_expected.to contain_staging__extract('mysql-connector-java-5.1.38.tar.gz').with({
             'target'  => '/opt/MySQL-connector',
-            'creates' => '/opt/MySQL-connector/mysql-connector-java-5.1.34',
+            'creates' => '/opt/MySQL-connector/mysql-connector-java-5.1.38',
           })}
         end
 
@@ -79,7 +79,7 @@ describe 'mysql_java_connector' do
           it { is_expected.to contain_file('/opt/jboss_app/lib/mysql-connector-java.jar')
             .with({
               'ensure' => 'link',
-              'target' => '/opt/MySQL-connector/latest/mysql-connector-java-5.1.34-bin.jar',
+              'target' => '/opt/MySQL-connector/latest/mysql-connector-java-5.1.38-bin.jar',
           })}
         end
 

--- a/spec/defines/links_spec.rb
+++ b/spec/defines/links_spec.rb
@@ -15,7 +15,7 @@ describe 'mysql_java_connector::links' do
           it { is_expected.to contain_file('/opt/tomcat_app/lib/mysql-connector-java.jar')
             .with({
               'ensure' => 'link',
-              'target' => '/opt/MySQL-connector/latest/mysql-connector-java-5.1.34-bin.jar',
+              'target' => '/opt/MySQL-connector/latest/mysql-connector-java-5.1.38-bin.jar',
           })}
         end
       end


### PR DESCRIPTION
Proposed fix for [Module defaults to http://cdn.mysql.com/Downloads/Connector-J/mysql-connector-java-5.1.34.tar.gz , which is a 404](https://github.com/puppet-community/puppet-mysql_java_connector/issues/5)

Change default version from 5.1.34 to 5.1.38. 5.1.38 is listed as the default version https://dev.mysql.com/downloads/connector/j/
