### PR TITLE
Update downloadURL

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,7 +25,7 @@ class mysql_java_connector (
   $product     = 'mysql-connector-java',
   $format      = 'tar.gz',
   $installdir  = '/opt/MySQL-connector',
-  $downloadURL = 'http://cdn.mysql.com/Downloads/Connector-J',
+  $downloadURL = 'https://dev.mysql.com/get/Downloads/Connector-J',
   $links       = [],
 ) {
 

--- a/spec/classes/mysql_java_connector_spec.rb
+++ b/spec/classes/mysql_java_connector_spec.rb
@@ -19,7 +19,7 @@ describe 'mysql_java_connector' do
               'target' => '/opt/MySQL-connector/mysql-connector-java-5.1.38',
           })}
           it { is_expected.to contain_staging__file('mysql-connector-java-5.1.38.tar.gz').with({
-            'source'  => 'http://cdn.mysql.com/Downloads/Connector-J/mysql-connector-java-5.1.38.tar.gz',
+            'source'  => 'https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.38.tar.gz',
             'timeout' => '300',
           })}
           it { is_expected.to contain_staging__extract('mysql-connector-java-5.1.38.tar.gz').with({


### PR DESCRIPTION
cdn.mysql.com currently throws an error. This seems to be where the mysql files live now.
