### PR TITLE
correct the link target to omit bin

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -1,3 +1,10 @@
 ---
 .travis.yml:
   secure: "tJxdfj1JCPSX61grU3tMGpRL5MRj38MoG0/NwlWC0N+lpchi6KV+DMdioqrPVwRtGixKlVYISS/2AeFVpZmrDtMzPKdkAOEoE2BT9LuRK7yC39ehzxOwwTNc9mfWBJhPOQsS7lGu7RJx3VfSxGCEI2TC9DvkkbJekhJmO5yAsFQ="
+  docker_sets:
+    - set: ubuntu1404-64
+    - set: ubuntu1604-64
+    - set: ubuntu1804-64
+    - set: centos7-64
+    - set: debian8-64
+    - set: debian9-64

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,22 @@ matrix:
   - rvm: 2.4.4
     bundler_args: --without system_tests development release
     env: PUPPET_VERSION="~> 5.0" CHECK=build DEPLOY_TO_FORGE=yes
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=centos7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=centos7-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_debug=true BEAKER_setfile=debian8-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
+  - rvm: 2.5.3
+    bundler_args: --without development release
+    env: PUPPET_INSTALL_TYPE=agent BEAKER_IS_PE=no BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_debug=true BEAKER_setfile=debian8-64 BEAKER_HYPERVISOR=docker CHECK=beaker
+    services: docker
 branches:
   only:
   - master

--- a/manifests/links.pp
+++ b/manifests/links.pp
@@ -10,7 +10,7 @@ define mysql_java_connector::links(
 
   file { "${name}/mysql-connector-java.jar":
     ensure => link,
-    target => "${installdir}/latest/${product}-${version}-bin.jar",
+    target => "${installdir}/latest/${product}-${version}.jar",
   }
 
 }

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -7,8 +7,8 @@ describe 'mysql_java_connector class' do
       pp = <<-EOS
       file { [ '/opt/tomcat_app', '/opt/jboss_app' ]:
         ensure => directory
-      } ->
-      class { 'mysql_java_connector': }
+      }
+      -> class { 'mysql_java_connector':
         links => [ '/opt/tomcat_app', '/opt/jboss_app' ]
       }
       EOS

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -26,7 +26,7 @@ describe 'mysql_java_connector class' do
       it { is_expected.to be_symlink }
     end
 
-    describe file('/opt/MySQL-connector/latest/mysql-connector-java-5.1.40-bin.jar') do
+    describe file('/opt/MySQL-connector/latest/mysql-connector-java-5.1.40.jar') do
       it { is_expected.to be_file }
       its(:md5sum) { is_expected.to eq '2ad5cfbcb388bee5a64c879c208c7652' }
     end

--- a/spec/classes/mysql_java_connector_spec.rb
+++ b/spec/classes/mysql_java_connector_spec.rb
@@ -68,12 +68,12 @@ describe 'mysql_java_connector' do
           it do
             is_expected.to contain_file('/opt/tomcat_app/lib/mysql-connector-java.jar').
               with('ensure' => 'link',
-                   'target' => '/opt/custom/latest/mysql-connector-java-4.99.111-bin.jar')
+                   'target' => '/opt/custom/latest/mysql-connector-java-4.99.111.jar')
           end
           it do
             is_expected.to contain_file('/opt/jboss_app/lib/mysql-connector-java.jar').
               with('ensure' => 'link',
-                   'target' => '/opt/custom/latest/mysql-connector-java-4.99.111-bin.jar')
+                   'target' => '/opt/custom/latest/mysql-connector-java-4.99.111.jar')
           end
         end
 
@@ -88,7 +88,7 @@ describe 'mysql_java_connector' do
           it do
             is_expected.to contain_file('/opt/jboss_app/lib/mysql-connector-java.jar').
               with('ensure' => 'link',
-                   'target' => '/opt/MySQL-connector/latest/mysql-connector-java-5.1.40-bin.jar')
+                   'target' => '/opt/MySQL-connector/latest/mysql-connector-java-5.1.40.jar')
           end
         end
       end

--- a/spec/defines/links_spec.rb
+++ b/spec/defines/links_spec.rb
@@ -16,7 +16,7 @@ describe 'mysql_java_connector::links' do
           it do
             is_expected.to contain_file('/opt/tomcat_app/lib/mysql-connector-java.jar').
               with('ensure' => 'link',
-                   'target' => '/opt/MySQL-connector/latest/mysql-connector-java-5.1.40-bin.jar')
+                   'target' => '/opt/MySQL-connector/latest/mysql-connector-java-5.1.40.jar')
           end
         end
       end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,31 +1,19 @@
-require 'beaker-rspec/spec_helper'
-require 'beaker-rspec/helpers/serverspec'
+require 'beaker-rspec'
+require 'beaker-puppet'
+require 'beaker/puppet_install_helper'
+require 'beaker/module_install_helper'
 
-unless ENV['BEAKER_provision'] == 'no'
-  hosts.each do |host|
-    # Install Puppet
-    if host.is_pe?
-      install_pe
-    else
-      install_puppet
-    end
-  end
-end
+run_puppet_install_helper unless ENV['BEAKER_provision'] == 'no'
+install_ca_certs unless ENV['PUPPET_INSTALL_TYPE'] =~ %r{pe}i
+install_module_on(hosts)
+install_module_dependencies_on(hosts)
 
 RSpec.configure do |c|
-  # Project root
-  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-
   # Readable test descriptions
   c.formatter = :documentation
-
-  # Configure all nodes in nodeset
-  c.before :suite do
-    # Install module and dependencies
-    puppet_module_install(source: proj_root, module_name: 'mysql_java_connector')
-    hosts.each do |host|
-      on host, puppet('module', 'install', 'puppetlabs-stdlib'), acceptable_exit_codes: [0, 1]
-      on host, puppet('module', 'install', 'puppet-archive'), acceptable_exit_codes: [0, 1]
+  hosts.each do |host|
+    if host[:platform] =~ %r{el-7-x86_64} && host[:hypervisor] =~ %r{docker}
+      on(host, "sed -i '/nodocs/d' /etc/yum.conf")
     end
   end
 end


### PR DESCRIPTION
The jar file doesn't seem to have "bin" in the name when it gets created.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
When the jar file gets deployed into $installdir, the resulting filename doesn't have "bin" appended to it. I've replaced the value of my `${installdir}` with `${installdir}` in the log below.

```
Notice: /Stage[main]/Mysql_java_connector::Install/Archive[${installdir}/mysql-connector-java-8.0.11.tar.gz]/ensure: download archive from https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-8.0.11.tar.gz to ${installdir}/mysql-connector-java-8.0.11.tar.gz and extracted in ${installdir} with cleanup
Notice: /Stage[main]/Mysql_java_connector::Install/File[${installdir}/latest]/ensure: created
Notice: /Stage[main]/Mysql_java_connector/Mysql_java_connector::Links[${installdir}]/File[/opt/jfrog/artifactory/tomcat/lib//mysql-connector-java.jar]/ensure: created
Notice: Applied catalog in 3.84 seconds
```
-->
